### PR TITLE
Add events calendar page

### DIFF
--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -37,6 +37,11 @@ export const navigationConfig: Record<string, NavigationItem[]> = {
       href: "/news",
       label: "Events & News",
       description: "Upcoming actions & trainings • News/press releases • Recaps"
+    },
+    {
+      href: "/calendar",
+      label: "Calendar",
+      description: "Shared calendar for actions, meetings, trainings, and events."
     }
   ],
 

--- a/src/pages/calendar.astro
+++ b/src/pages/calendar.astro
@@ -1,0 +1,41 @@
+---
+import Layout from "../layouts/Layout.astro";
+
+const calendarSrc =
+  "https://calendar.google.com/calendar/embed?src=jpmcworkers%40gmail.com&ctz=America%2FNew_York";
+---
+
+<Layout
+  title="Events Calendar"
+  description="Upcoming JPMC Workers Alliance events and shared calendar dates."
+>
+  <section class="max-w-6xl mx-auto space-y-6">
+    <div class="space-y-3">
+      <p class="text-lg text-muted">
+        Upcoming actions, meetings, trainings, and other shared dates from the
+        JPMC Workers Alliance calendar.
+      </p>
+      <a
+        href="https://calendar.google.com/calendar/u/1?cid=anBtY3dvcmtlcnNAZ21haWwuY29t"
+        class="inline-flex items-center font-semibold text-jpmc-blue hover:text-jpmc-blue-700 dark:text-jpmc-blue-300 dark:hover:text-jpmc-blue-200"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Open in Google Calendar
+      </a>
+    </div>
+
+    <div
+      class="overflow-hidden rounded-lg border border-jpmc-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
+    >
+      <iframe
+        src={calendarSrc}
+        title="JPMC Workers Alliance Google Calendar"
+        class="block h-[720px] w-full"
+        loading="lazy"
+        frameborder="0"
+        scrolling="no"
+      ></iframe>
+    </div>
+  </section>
+</Layout>

--- a/tests/calendar.spec.ts
+++ b/tests/calendar.spec.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "@playwright/test";
+
+test("Visitors can view the shared events calendar", async ({ page }) => {
+  await page.goto("http://localhost:4321/calendar");
+
+  await expect(
+    page.getByRole("heading", { name: "Events Calendar", level: 1 })
+  ).toBeVisible();
+
+  await expect(
+    page.locator('iframe[title="JPMC Workers Alliance Google Calendar"]')
+  ).toHaveAttribute(
+    "src",
+    /https:\/\/calendar\.google\.com\/calendar\/embed\?src=jpmcworkers%40gmail\.com/
+  );
+});

--- a/tests/link-validation.spec.js
+++ b/tests/link-validation.spec.js
@@ -17,6 +17,9 @@ test('Desktop overall Linkage', async ({ page, isMobile }) => {
           - link "Events & News":
             - /url: /news
         - listitem:
+          - link "Calendar":
+            - /url: /calendar
+        - listitem:
           - link "Learn the Issues":
             - /url: /issues-and-resources
         - listitem:
@@ -104,6 +107,8 @@ test('Mobile overall Linkage', async ({ page, isMobile }) => {
       - /url: /join-us
     - link "Events & News":
       - /url: /news
+    - link "Calendar":
+      - /url: /calendar
     - link "Organizer Toolkit":
       - /url: /content
     - link "Media Library":


### PR DESCRIPTION
## Summary

- Add an `/calendar` page with the shared JPMC Workers Alliance Google Calendar embed.
- Add Calendar to the site navigation.
- Cover the page and navigation with Playwright checks.

## Screenshots

### Phone

![Phone calendar screenshot](https://raw.githubusercontent.com/b-koop/workers.github.io/calendar-screenshots/docs/pr-screenshots/calendar-phone-screenshot.png)

### Tablet

![Tablet calendar screenshot](https://raw.githubusercontent.com/b-koop/workers.github.io/calendar-screenshots/docs/pr-screenshots/calendar-tablet-screenshot.png)

### Desktop

![Desktop calendar screenshot](https://raw.githubusercontent.com/b-koop/workers.github.io/calendar-screenshots/docs/pr-screenshots/calendar-desktop-screenshot.png)

### Widescreen

![Widescreen calendar screenshot](https://raw.githubusercontent.com/b-koop/workers.github.io/calendar-screenshots/docs/pr-screenshots/calendar-widescreen-screenshot.png)

## Validation

- `pnpm build`
- `pnpm exec playwright test tests/calendar.spec.ts tests/link-validation.spec.js --project=chromium`
- `pnpm exec playwright test --project=chromium`
