### PR TITLE
feat: add June 2026 newsletter

### DIFF
--- a/src/pages/newsletters/2026-06.md
+++ b/src/pages/newsletters/2026-06.md
@@ -10,7 +10,7 @@ tags:
   ["newsletter", "june", "2026", "pride", "ai", "organizing", "volunteers"]
 layout: ~/layouts/Markdown.astro
 ---
-<h2>Happy Pride, {{ FirstName | default: 'Comrade' }}!
+<h2>Happy Pride, Comrade!
 </h2>
 <p>This month we celebrate Pride &mdash; and it's a fitting time to talk about something we believe deeply: <strong>unions are one of the most powerful tools available to the people who need power most.</strong>
 </p>

--- a/src/pages/newsletters/2026-06.md
+++ b/src/pages/newsletters/2026-06.md
@@ -1,0 +1,186 @@
+---
+title: "JWA Newsletter - June 2026: Pride, AI, and Getting Involved"
+date: 2026-06-14
+version: "1.0"
+author: "JWA Team"
+description: "June newsletter covering Pride and solidarity, AI in banking, banker outreach, the Tech Workers Guild, volunteer needs, pride buttons, and ways to stay connected."
+excerpt: "This month we celebrate Pride, talk about unions as tools for people who need power most, share AI and banker outreach updates, and ask members to get involved."
+featured: false
+tags:
+  ["newsletter", "june", "2026", "pride", "ai", "organizing", "volunteers"]
+layout: ~/layouts/Markdown.astro
+---
+<h2>Happy Pride, {{ FirstName | default: 'Comrade' }}!
+</h2>
+<p>This month we celebrate Pride &mdash; and it's a fitting time to talk about something we believe deeply: <strong>unions are one of the most powerful tools available to the people who need power most.</strong>
+</p>
+<ol>
+    <li>Unions & the People Who Need Them Most <em>(new recurring feature)</em>
+    </li>
+    <li>AI in Banking: Take the Survey
+    </li>
+    <li>AI at Work: Quality Over Convenience
+    </li>
+    <li>Banker Outreach Campaign
+    </li>
+    <li>Tech Workers Guild
+    </li>
+    <li>Get Involved: Volunteers & Officers Needed
+    </li>
+    <li>Pride Buttons &mdash; Get Yours!
+    </li>
+    <li>Send Us Your Priorities
+    </li>
+    <li>Join, Donate & Stay Connected
+    </li>
+</ol><hr>
+<p><br>
+</p>
+<h3>Unions & the People Who Need Them Most
+</h3>
+<p><em>This is the first installment of a recurring feature. Each month, we'll take a closer look at how unions and collective bargaining benefit a specific group. This month: an overview. Going forward, we'll go deeper.</em>
+</p>
+<p>It is sometimes said that unions are a relic &mdash; that they served their purpose in the days of coal mines and textile factories and have little relevance now. We disagree, and the data does too.
+</p>
+<p>Unions raise wages across the board, but the gains are not evenly distributed &mdash; they are <strong>largest for the workers who start with the least.</strong> According to the Economic Policy Institute, the union wage premium is highest for Black workers, Latino workers, workers without college degrees, and workers in the bottom half of the wage distribution. In other words, unions don't just help workers in the abstract. They close gaps.
+</p>
+<p>Beyond wages, union contracts provide protections that matter more when you have less margin for error: just-cause requirements before termination, consistent and transparent disciplinary procedures, grievance processes that give workers a real voice, and healthcare coverage that doesn't disappear when your manager decides you're no longer needed.
+</p>
+<p>LGBTQ+ workers, workers with disabilities, and women have all historically seen stronger workplace protections under union contracts than in comparable non-union workplaces &mdash; not because unions are perfect, but because a contract is harder to ignore than a promise.
+</p>
+<p>Pride month is a good time to ask: who benefits when workers have power? The answer is everyone &mdash; but especially those who have the least of it to begin with.
+</p>
+<p>This is not hypothetical, and it isn't new. When Reform UK took control of Durham County Council last year and cut funding for Durham Pride, it was trade unions &mdash; miners, postal workers, train drivers &mdash; who stepped in and raised more money than the council ever contributed, turning what could have been a cancellation into the biggest Durham Pride in history. That solidarity has roots going back to the miners' strikes of the 1980s, when LGBTQ+ activists fundraised for mining communities. Decades later, the miners returned the favor. <a href="https://www.theguardian.com/world/2026/may/30/durham-pride-trade-unions-beat-reform-funding-axe">That's what solidarity looks like.</a>
+</p>
+<p>Closer to home, at JPMC, many of the more specific Pride-related BRGs have had their budgets cut and their Teams channels removed. If you've lost a community you valued, we'd like to be part of filling that gap. The JWA is committed to being an open, welcoming space for everyone &mdash; <a href="https://jpmcworkers.com/discord">come join us</a>.
+</p>
+<p><em>Next month, we'll take a deeper look at a specific group. Have a suggestion? Reply to this email or let us know <a href="https://jpmcworkers.com/discord">on Discord</a>.</em>
+</p><hr>
+<p><br>
+</p>
+<h3>AI in Banking: Take the Survey
+</h3>
+<p>Our partners at the Committee for Better Banks are collecting data from banking workers about their experiences with AI implementation.
+</p>
+<p>If you work in banking and have concerns &mdash; or even just observations &mdash; about how AI is being rolled out at your institution, <a href="https://actionnetwork.org/forms/do-you-work-in-banking-and-are-worried-about-ai-implementation-take-our-short-survey">this survey is for you</a>. The data collected will be used to support workers and advocate for responsible AI policies across the industry.
+</p>
+<p>It takes just a few minutes. Please share it with coworkers as well &mdash; the more responses, the stronger the case.
+</p><hr>
+<p><br>
+</p>
+<h3>AI at Work: Quality Over Convenience
+</h3>
+<p>There is a conversation happening across many workplaces right now that we think deserves to be named directly.
+</p>
+<p>AI tools can save time, reduce tedious work, and help people focus on what matters. We are not here to argue otherwise.
+</p>
+<p>But there is a version of AI use that concerns us: the one where the <em>appearance</em> of work replaces the <em>substance</em> of it. Where the goal shifts from "did I do this well?" to "did I produce something quickly enough?" Where a first draft becomes a final product because it passed a glance, not a standard.
+</p>
+<p>This is not a criticism of any individual worker. Workers do not set the conditions under which they work (except with a union contract). When speed is rewarded and thoroughness is not, people rationally optimize for speed.
+</p>
+<p>But when AI-assisted shortcuts quietly become the norm, the quality of work declines &mdash; and the workers who built careers on genuine skill and craft get undercut by output that looks similar on the surface.
+</p>
+<p>A union contract that sets clear expectations around quality, defines what it means to do a job well, and protects workers from being measured purely by volume is one tool for addressing this. Another is workers talking to each other &mdash; openly, without fear &mdash; about what they are actually experiencing on the floor.
+</p>
+<p>If this resonates with you, we want to hear about it. Reply to this email or find us <a href="https://jpmcworkers.com/discord">on Discord</a>.
+</p><hr>
+<p><br>
+</p>
+<h3>Banker Outreach Campaign
+</h3>
+<p>The JPMC Workers Alliance recently launched a direct mail campaign targeting workers at JPMC branch locations.
+</p>
+<p>This effort is led by the <strong>Lunch Bunch</strong> &mdash; a group of members who meet every Wednesday at noon at the Polaris tech center. So far, they've mailed a trifold and organizing booklet to workers at <strong>three different branch locations</strong> &mdash; 44 mailings in total. This is about reaching JPMC workers who may never see an internal flyer or stumble across our Discord: the branch bankers, the tellers, the customer-facing employees who are often the most exposed and the least heard.
+</p>
+<p>If you have a connection to a JPMC branch &mdash; whether you work there, used to work there, or know someone who does &mdash; we'd love your help identifying locations and getting materials where they need to go.
+</p>
+<p>Reach out <a href="https://jpmcworkers.com/discord">on Discord</a> to learn more. Union members who participate can also be reimbursed for postage costs &mdash; a reimbursement form is available to vetted, union-eligible members in our Discord server.
+</p><hr>
+<p><br>
+</p>
+<h3>Tech Workers Guild
+</h3>
+<p>One of our own members, Beth, is building something new: a <strong>guild for software developers and tech workers</strong> &mdash; and we think it's worth your attention.
+</p>
+<p>The core idea is to treat tech work as a genuine professional discipline, with the structural safeguards, ethical standards, mentorship pathways, and collective institutions that other engineering professions take for granted. Think of it as combining the best elements of a professional guild, a labor union, and a workforce development network &mdash; centered on workers rather than on corporate hiring needs.
+</p>
+<p>The goals include a shared code of professional conduct, community-recognized certifications tied to demonstrated skill and experience, mentorship and apprenticeship structures, and eventually a hiring network that prioritizes long-term professional sustainability over short-term profit extraction.
+</p>
+<p>If you're a tech worker or software developer and this resonates with you, reply to this email or <a href="https://jpmcworkers.com/discord">join the JWA Discord</a> for more information!
+</p><hr>
+<p><br>
+</p>
+<h3>Get Involved: Volunteers & Officers Needed
+</h3>
+<p>Every event we've hosted, every mailing we've sent, every newsletter you've read &mdash; none of it happened automatically. It happened because specific people decided to spend specific hours making it happen.
+</p>
+<p>This year, we've done less than we'd like. The reason is simple: fewer hands. Organizing a company the size of JPMC is not something a small number of people can do alone, no matter how committed they are. The scale of what we're up against requires the scale of who we are &mdash; and right now, we're not operating at our full strength.
+</p>
+<p>Here's what we know for certain: <strong>this works when people show up.</strong> The February valentines happened in four cities because JPMC employees in those cities stepped up to lead them. The OSHA complaint in Elgin worked because one member raised their hand. The banker mailing campaign exists because someone printed trifolds, a group sat down to fold them, and addresses were written by hand.
+</p>
+<p>You don't need to quit your day job. You don't need to be an expert in labor law. You don't need to do anything dramatic. You just need to be willing to do <em>something.</em>
+</p>
+<p>If you've ever thought "I wish someone would unionize JPMC" &mdash; you're looking at the someone.
+</p>
+<p>We're also in immediate need of officers to fill several open roles, including <strong>Secretary</strong> and <strong>Assistant Treasurer</strong>. These positions give you a real stake in how the organization runs and grows. If you or someone you know might be a good fit, please reply to this email or reach out <a href="https://jpmcworkers.com/discord">on Discord</a>.
+</p>
+<p>Not sure what role makes sense for you? Just show up to a meeting. We'll figure it out together.
+</p>
+<p><strong>Looking for inspiration?</strong> Check out <a href="https://unitedwizardsofthecoast.com/">United Wizards of the Coast</a> &mdash; the union of workers behind <em>Magic: The Gathering Arena</em>, organizing with the Communications Workers of America. They are a dedicated group of tech workers building worker power inside a large corporation, one conversation at a time. Sound familiar?
+</p><hr>
+<p><br>
+</p>
+<h3>Pride Buttons &mdash; Get Yours!
+</h3>
+<p>Last year, we produced over a thousand Pride-themed union button pins &mdash; and we'd love to see them actually get worn.
+</p>
+<p>If you work in Columbus, especially at the <strong>Polaris tech center</strong>, you can get one just by asking. Reach out to any JWA member you know, or find us <a href="https://jpmcworkers.com/discord">on Discord</a>.
+</p><hr>
+<p><br>
+</p>
+<h3>Send Us Your Priorities
+</h3>
+<p>We want to hear from you &mdash; not just as a way of saying that, but because we genuinely need your input to focus our efforts where they'll do the most good.
+</p>
+<p><strong>What issues matter most to you at work right now?</strong> What would you want a union contract to address first? Where do you feel most unprotected, most unheard, or most frustrated?
+</p>
+<p>Reply to this email with your thoughts. You can also share ideas for how to break big goals into manageable actions &mdash; we're always looking for ways to make organizing feel less overwhelming and more doable.
+</p>
+<p>The union is shaped by the people in it. The more voices we hear, the better it becomes.
+</p><hr>
+<p><br>
+</p>
+<h3>Join, Donate & Stay Connected
+</h3>
+<p>The JWA does not charge dues. We run on the time and goodwill of our members, and the financial support of those who can afford to give.
+</p>
+<p>Ready to get involved? <a href="https://jpmcworkers.com/discord">Join us on Discord</a> &mdash; that's where the organizing happens, where meetings are held, and where you'll find your people.
+</p>
+<p>If you'd like to support us financially, even a small contribution makes a real difference. Every dollar goes toward organizing, events, and materials. <a href="https://actionnetwork.org/fundraising/jwa-organizing-expenses?source=direct_link&">Donate here.</a>
+</p>
+<p>Swag is coming! We're working on a request form for union merchandise &mdash; stay tuned for details.
+</p><hr>
+<p><br>
+</p>
+<h3>UNION MEETINGS
+</h3>
+<p>We hold union meetings on <a href="https://jpmcworkers.com/discord">our Discord server</a>. Check there for the current schedule, or <a href="https://calendar.google.com/calendar/u/1?cid=anBtY3dvcmtlcnNAZ21haWwuY29t">add our calendar to your Google account</a> to stay automatically up to date.
+</p>
+<p>If you are union-eligible and haven't joined us yet, we hope to see you there. Not sure about your eligibility? <a href="https://jpmcworkers.com/mgr">Check our resource for managers</a> for a clearer picture.
+</p><hr>
+<p><br>
+</p>
+<h3>REMEMBER
+</h3>
+<p>The union is us. We are the union.
+</p>
+<h4>Change is coming. Be a part of it.
+</h4>
+<p>Excitedly Yours,
+</p>
+<p>The JPMC Workers Alliance
+</p>
+<p><em>Written with love by Jesse, Beth, and Reggie</em>
+</p>
+<p><em><strong>P.S.</strong></em> Previous editions are <a href="https://jpmcworkers.com/newsletters">available on our website</a>!
+</p>


### PR DESCRIPTION
## Summary

- Add the June 2026 newsletter at `/newsletters/2026-06/`
- Preserve the provided newsletter HTML body as-is after Astro frontmatter

## Verification

- `pnpm run build` passed

Note: build logs include existing DNS warnings from external news metadata fetches under restricted network, but the build completed successfully.
